### PR TITLE
PSEUDOMOTOR: add a position law [Also fix #2]

### DIFF
--- a/borealis/controller/controller_base.py
+++ b/borealis/controller/controller_base.py
@@ -174,15 +174,21 @@ class DummyCtrl(Controller):
     """When in need for a controller but no access to a real device."""
 
     def __init__(self):
-        self.position = 0
+        self.position = {}
         LOGGER.info('Dummy controller initialised')
         pass
 
     def move_axis(self, axis_id: str, target: float = 0):
-        self.position = target
+        self.position[axis_id] = target
 
     def get_axis_position(self, axis_id: str):
-        return self.position
+        try:
+            pos = self.position[axis_id]
+        except KeyError:
+            self.position[axis_id] = 0
+            pos = self.position[axis_id]
+
+        return pos
 
     def is_axis_ready(self, axis_id: str):
         return True

--- a/borealis/pseudo_motor.py
+++ b/borealis/pseudo_motor.py
@@ -113,7 +113,7 @@ class PseudoMotor:
             motor_pos = self._conversion_laws[idx](pos)
             motor.amove(motor_pos)
 
-    def scan(self, start: float, stop: float, step: int, acq_time: float = 0):
+    def scan(self, start: float, stop: float, step: float, acq_time: float = 0):
         """
         Scan, with or without acquisition.
 

--- a/borealis/pseudo_motor.py
+++ b/borealis/pseudo_motor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Union
+from typing import Union, Callable
 import time
 
 import numpy as np
@@ -15,7 +15,8 @@ LOGGER = logging.getLogger(__name__)
 class PseudoMotor:
     """Class for a basic pseudo-motor, meaning a collection of Motor objects plus 0 or 1 detector."""
 
-    def __init__(self, alias: str, motors: list[Motor, PseudoMotor], geometries: list, detector: Union[Detector, None] = None) -> None:
+    def __init__(self, alias: str, motors: list[Motor, PseudoMotor], geometries: list,
+                 position_law: Callable[[list], float], detector: Union[Detector, None] = None) -> None:
         """
 
         Parameters
@@ -24,8 +25,11 @@ class PseudoMotor:
             Name of the pseudo-motor
         motors : list[Motor, PseudoMotor]
             List of Motor or PseudoMotor objects.
-        geometries : list[fct]
-            List of conversion functions (e.g. lambda (x,y): x), one for each motor.
+        geometries : list[Callable[float, float]
+            List of conversion functions (e.g. lambda (x: ax + b), one for each motor.
+        position_law : Callable[[list], float]
+            Function that takes as input the list of (pseudo)-motors as it was given at instantiation and returns
+             a single float.
         detector
             Instance of Detector.
         """
@@ -37,16 +41,16 @@ class PseudoMotor:
                          len(motors), len(geometries))
             raise ValueError(f"Length of motor list ({len(motors)}) does not match the length of "
                              f"geometry list ({len(geometries)})")
-        self._motor_name = alias
+        self.motor_name = alias
         self._motors = motors
         self._conversion_laws = geometries
         self._detector = detector
-        self._position_law = lambda x: x[0].user_position
+        self._position_law = position_law
 
-        LOGGER.info("PseudoMotor %s created.", self._motor_name)
+        LOGGER.info("PseudoMotor %s created.", self.motor_name)
 
     @property
-    def position(self):
+    def user_position(self):
         return self._position_law(self._motors)
 
     @property
@@ -68,7 +72,7 @@ class PseudoMotor:
         str
 
         """
-        print('{} at : {:6.2f} (user)'.format(self._motor_name, self.position))
+        print('{} at : {:6.2f} (user)'.format(self.motor_name, self.user_position))
 
     def where_all(self):
         """
@@ -99,7 +103,7 @@ class PseudoMotor:
         for idx, motor in enumerate(self._motors):
             motor_pos = self._conversion_laws[idx](dial)
             motor.check_soft_limits(motor_pos)
-            LOGGER.debug("Valid dial %.2f for (pseudo)motor %s", motor_pos, motor.motor_name)
+            LOGGER.debug("Valid dial %.3f for (pseudo)motor %s", motor_pos, motor.motor_name)
 
     def amove(self, pos):
         self._check_is_ready()
@@ -109,10 +113,31 @@ class PseudoMotor:
             motor_pos = self._conversion_laws[idx](pos)
             motor.amove(motor_pos)
 
-    def scan(self, start, stop, step, acq_time):
-        self._check_is_ready()
-        start_time = time.time()
+    def scan(self, start: float, stop: float, step: int, acq_time: float = 0):
+        """
+        Scan, with or without acquisition.
 
+        Parameters
+        ----------
+        start : float
+            Start of interval.  The interval includes this value.
+        stop : float
+            End of interval.  The interval does not include this value.
+        step : float
+            Spacing between values.  For any output `out`, this is the distance
+            between two adjacent values, ``out[i+1] - out[i]``.
+        acq_time : float
+            If a Detector is attached to the pseudo-motor, will perform an acquisition for this time.
+            If no detector is defined and acq_time > 0, it will sleep for this time.
+
+        Returns
+        -------
+        spectra : ndarray
+            Array of MCA objects.
+        """
+        self._check_is_ready()
+
+        start_time = time.time()
         LOGGER.info("Scan starts...\n")
         idx_col_width = 5
         pos_col_width = 8
@@ -121,52 +146,28 @@ class PseudoMotor:
         LOGGER.info(f"| {'#':>{idx_col_width}} | {'pos':>{pos_col_width}} | {'time':>{time_col_width}} "
                     f"| {'count tot.':>{count_col_width}} |")
         LOGGER.info(f"| {'-'*idx_col_width} | {'-'*pos_col_width} | {'-'*time_col_width} | {'-'*count_col_width} |")
+
         spectra = []
         for (idx, position) in enumerate(np.arange(start, stop, step, dtype=np.float32)):
             try:
                 self.amove(position)
-            except RuntimeError:  # TODO: change to MotorNotReady error once available
+            except RuntimeError as exc:  # TODO: change to MotorNotReady error once available
                 LOGGER.error(
-                    "Scan interrupted at position %f due to motor not being ready yet (i.e. not idle).",
-                    position)
-                raise RuntimeError(f"Scan interrupted at position {position} "
-                                   f"due to motor not being ready yet (i.e. not idle).")
+                    "Scan interrupted at position %.2f",position)
+                raise RuntimeError(f"Scan interrupted at position {position}") from exc
+
             counts = np.nan
             if self._detector is not None:
-                assert acq_time is not None
+                assert acq_time > 0.
                 spectrum = self._detector.acquisition(acq_time)
                 counts = spectrum.counts.sum()
                 spectra.append(spectrum)
-            elif acq_time is not None:
+            elif acq_time > 0.:
                 time.sleep(acq_time)
+
             LOGGER.info(f"| {idx:{idx_col_width}.0f} | {position:{pos_col_width}.3f} "
                         f"| {acq_time:{time_col_width}.2f} | {counts:{count_col_width}.0f} |")
-        LOGGER.info(f"\n   Scan ended succesfully. Total duration was: {time.time()-start_time:.2f} s\n")
-        return np.array(spectra)
 
-# class Theta(ABC):
-#
-#     def __init__(self, radius, spectro_cmpt):
-#         """Provide pseudo motor to perform angle."""
-#         self.radius = radius
-#         self._det_y = spectro_cmpt['det_y'] if 'det_y' in spectro_cmpt else None
-#         self._src_y = spectro_cmpt['src_y'] if 'src_y' in spectro_cmpt else None
-#         ...
-#
-#     def mvabs(pos):
-#         if self._det_y is not None:
-#             self.det_y.move(self.get_src_x(pos))
-#         if self._src_x is not None:
-#             self.det_y.move(self.get_src_x(pos))
-#         ...
-#
-#     def scan(start, stop, step):
-#         for pos in range(start, stop, step):
-#             self.mvabs(pos)
-#
-#     def get_src_x(pos):
-#         return 0
-#
-#     @staticmethod
-#     def torad(theta):
-#         return pi*theta/180
+        LOGGER.info(f"\n   Scan ended succesfully. Total duration was: {time.time()-start_time:.2f} s\n")
+
+        return np.array(spectra)

--- a/examples/revontuli_xas.py
+++ b/examples/revontuli_xas.py
@@ -90,8 +90,6 @@ INI_FILEPATH = "C:/LocalData/renebes/borealis/examples/KETEK_DPP2_usb2.ini"
 det = KetekAXASM('ketek', INI_FILEPATH)
 
 ### INITIALIZATION OF PSEUDO-MOTORS ###
-mono_multiaxis = PseudoMotor([monox, monor], [geo_monox, geo_monor])
-tube_multiaxis = PseudoMotor([tubex, tubey, tuber], [geo_tubex, geo_tubey, geo_tuber])
 theta = PseudoMotor([tubex, tubey, tuber, monox, monor], [geo_tubex, geo_tubey, geo_tuber, geo_monox, geo_monor],det)
 
 ### INITIALIZATION OF X-RAY TUBE ###

--- a/tests/test_pseudomotor.py
+++ b/tests/test_pseudomotor.py
@@ -4,6 +4,9 @@ Created on Mon Jul 29 10:18:23 2024
 
 @author: renebes
 """
+import math
+
+import pytest
 
 from borealis.controller.controller_base import DummyCtrl
 from borealis.motor import Motor
@@ -17,7 +20,90 @@ def test_pseudomotor_const():
     mot2 = Motor('DummyMotor2', '2', 0, ctrl)
     geo1 = lambda x: x
     geo2 = lambda x: -x
-    PseudoMotor('DummyPseudoMotor', [mot1, mot2], [geo1, geo2])
+    position_law = lambda x: x[0].user_position
+    PseudoMotor('DummyPseudoMotor', [mot1, mot2], [geo1, geo2], position_law)
+
+
+def test_pseudomotor_move():
+    """
+    Check  the move method.
+
+    The tested pseudomotor is composed of one pseudomotor and two motors.
+    The first motor position is checked.
+    The second motor position is checked to be
+    Pseudomotor position in the console output is  (user).
+
+    """
+    ctrl = DummyCtrl()
+    mot1 = Motor('DummyMotor1', '1', -1, ctrl)
+    mot1.amove(3)
+    assert mot1.dial_position == 4
+    assert mot1.user_position == 3
+
+    mot2 = Motor('DummyMotor2', '2', 2, ctrl)
+    mot2.amove(2)
+    assert mot2.dial_position == 0
+    assert mot2.user_position == 2
+
+    geo1 = lambda x: x
+    geo2 = lambda x: 10 * x
+    position_law = lambda x: x[0].user_position
+    pseudo1 = PseudoMotor('DummyPseudoMotor1', [mot1, mot2], [geo1, geo2], position_law)
+    pseudo1.amove(10)
+
+    assert mot1.user_position == 10
+    assert mot1.dial_position == 11
+    assert mot2.user_position == 100
+    assert mot2.dial_position == 98
+
+    geo3 = lambda x: x
+    pseudo2 = PseudoMotor('DummyPseudoMotor2', [pseudo1], [geo3], position_law)
+    pseudo2.amove(42)
+    assert pseudo1.user_position == 42
+    assert pseudo2.user_position == 42
+    assert mot1.user_position == 42
+    assert mot1.dial_position == 43
+    assert mot2.user_position == 420
+    assert mot2.dial_position == 418
+
+
+def test_postion_law_conversion():
+    ctrl = DummyCtrl()
+    mot1 = Motor('DummyMotor1', '1', 0, ctrl)
+    mot2 = Motor('DummyMotor2', '2', 0, ctrl)
+    geo1 = lambda x: x * math.cos(math.pi / 3)  # PM(user) -> M(user)
+    geo2 = lambda x: x * math.sin(math.pi / 3)
+    pos_law = lambda x: math.sqrt(x[0].user_position ** 2 + x[1].user_position ** 2)
+    pseudo = PseudoMotor("pseudo", [mot1, mot2], [geo1, geo2], position_law=pos_law)
+
+    pseudo.amove(1)
+    assert mot1.user_position == pytest.approx(0.5)
+    assert mot2.user_position == pytest.approx(math.sqrt(3) / 2)
+    assert pseudo.user_position == pytest.approx(1)
+
+    # Simulate Theta and Energy pseudo-motors for Si999 crystal
+    geo1 = lambda x: math.cos(x * math.pi / 180)
+    geo2 = lambda x: math.sin(x * math.pi / 180)
+    pos_law = lambda x: math.acos(x[0].user_position) * 180 / math.pi
+    pm_theta = PseudoMotor("pseudo", [mot1, mot2], [geo1, geo2], position_law=pos_law)
+
+    pm_theta.amove(45)
+    assert mot1.user_position == pytest.approx(math.sqrt(2) / 2)
+    assert mot2.user_position == pytest.approx(math.sqrt(2) / 2)
+    assert pm_theta.user_position == pytest.approx(45)
+
+    d_si999 = 0.34836
+    theta_to_energy = lambda x: 12.39842 / (2 * d_si999 * math.sin(x[0].user_position * math.pi / 180))
+    energy_to_theta = lambda x: math.asin(12.39842 / (2 * d_si999 * x)) * 180 / math.pi
+
+    pm_energy = PseudoMotor('energy', [pm_theta], [energy_to_theta],
+                            position_law=theta_to_energy)
+    pm_energy.amove(18.42)
+    assert pm_theta.user_position == pytest.approx(75.0368)
+    assert pm_energy.user_position == pytest.approx(18.42)
+
+    pm_energy.scan(18.4, 18.5, 0.01, acq_time=0.1)
+
 
 ###############################################################
 ### Tests below are only aimed to check the console output  ###
@@ -38,9 +124,11 @@ def test_pseudomotor_where():
     geo2 = lambda x: x
     mot1.amove(42)
     assert mot1.dial_position == 36
-    pseudo = PseudoMotor('DummyPseudoMotor', [mot1, mot2], [geo1, geo2])
-    assert pseudo.position == 42
+    position_law = lambda x: x[0].user_position
+    pseudo = PseudoMotor('DummyPseudoMotor', [mot1, mot2], [geo1, geo2], position_law)
+    assert pseudo.user_position == 42
     pseudo.where()
+
 
 def test_pseudomotor_where_all():
     """
@@ -58,9 +146,11 @@ def test_pseudomotor_where_all():
     mot1 = Motor('DummyMotor1', '1', -1, ctrl)
     mot2 = Motor('DummyMotor2', '2', 2, ctrl)
     geo = lambda x: x
-    pseudo1 = PseudoMotor('DummyPseudoMotor1', [mot1, mot2], [geo, geo])
-    pseudo2 = PseudoMotor('DummyPseudoMotor2', [pseudo1, mot1, mot2], [geo, geo, geo])
+    position_law = lambda x: x[0].user_position
+    pseudo1 = PseudoMotor('DummyPseudoMotor1', [mot1, mot2], [geo, geo],position_law)
+    pseudo2 = PseudoMotor('DummyPseudoMotor2', [pseudo1, mot1, mot2], [geo, geo, geo], position_law)
     pseudo2.where_all()
+
 
 def test_pseudomotor_scan():
     """
@@ -73,10 +163,11 @@ def test_pseudomotor_scan():
     mot1 = Motor('DummyMotor1', '1', 1, ctrl)
     mot2 = Motor('DummyMotor2', '2', 2, ctrl)
     geo1 = lambda x: x
-    geo2 = lambda x: 2*x
-    pseudo1 = PseudoMotor('DummyPseudoMotor1', [mot1, mot2], [geo1, geo2])
+    geo2 = lambda x: 2 * x
+    position_law = lambda x: x[0].user_position
+    pseudo1 = PseudoMotor('DummyPseudoMotor1', [mot1, mot2], [geo1, geo2], position_law)
     pseudo1.scan(2, 5, .5, acq_time=.1)
 
     det = DummyDet()
-    pseudo2 = PseudoMotor('DummyPseudoMotor1', [mot1, mot2], [geo1, geo2], detector=det)
+    pseudo2 = PseudoMotor('DummyPseudoMotor1', [mot1, mot2], [geo1, geo2], position_law, detector=det)
     pseudo2.scan(0, 5, 1, acq_time=.5)


### PR DESCRIPTION
Add a position law to return the pseudo-motor position in the same "unit" as the one used for target